### PR TITLE
Remove button - didn't make sense

### DIFF
--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="row">
          <p>
-          <a class="btn btn-primary btn-lg" href="/properties" role="button">Back to Properties</a>
+<!--           <a class="btn btn-primary btn-lg" href="/properties" role="button">Back to Properties</a> -->
         <%if current_user %>
         <% if !current_user.favorite_properties.exists?(z_id: params[:id]) %>
           <%= link_to 'Add to Favorites', favorite_properties_path(:favorite_properties => {:z_id => @property_hash["result"]["id"], :address => @property_hash["result"]["location"]["all"], :address => @property_hash["result"]["location"]["all"], :rating => 0, :price =>@property_hash["result"]["price"]["monthly"], :picture => @property_hash["result"]["photos"][0]["medium"], :title => @property_hash["result"]["attr"]["propType"]["text"]}), {:method=>:post, class: "btn btn-primary btn-lg", role: "button"} %>


### PR DESCRIPTION
I removed the back to properties button on the property#show page because it didnt make sense hwen i was running through it at home. Partially because the search button is on the top nav, and next because if you go to your user fave page and then check out the property the "Back to Properties" is deceiving and makes you think youre taking about favorites when really its the property search.

ANywhoo its minor so if ya disagree I can put it back int he AM..

Get some rest loves!
